### PR TITLE
Handle empty battery learn state

### DIFF
--- a/dell_omsa/checks/dell_omsa_battery
+++ b/dell_omsa/checks/dell_omsa_battery
@@ -40,7 +40,7 @@ def check_dell_omsa_battery(item, params, info):
             continue
         state = int(line[2])
         pc = int(line[3])
-        lstate = int(line[4])
+        lstate = int(line[4]) if line[4] else 16
         try:
             info_text = "%s: State %s, Predicted Capacity %s, Learn State %s" % (line[1],
                                                                                  bat_state[state],


### PR DESCRIPTION
Our Dell PowerEdge T420 running OMSA 7.3 on Windows Server 2008 R2 do not report the 'Idle' battery learn state. Instead .1.3.6.1.4.1.674.10893.1.20.130.15.1.12 is just not present. This results in an empty string in line[4].

This patch modifies dell_osma_battery to interpret this as an idle battery learn state.
