### PR TITLE
added mongodb port number to description of service

### DIFF
--- a/mongodb/checks/check_mongodb
+++ b/mongodb/checks/check_mongodb
@@ -62,7 +62,7 @@ def check_mongodb_description(params):
 
     action, settings, maxlag, mappedmem, ssl, replicaset, perfdata = params
 
-    description += " %s" % action
+    description += " %s port %s" % (action, settings['port'])
 
     return description
 


### PR DESCRIPTION
in case of multiple mongodb instances on the same server it was impossible to add checks for each instance due to description of service conflict. Adding mongodb port to the service description should fix this
