### PR TITLE
size_trend.include has to be after df.include

### DIFF
--- a/huawei/checks/huawei_capacity
+++ b/huawei/checks/huawei_capacity
@@ -42,6 +42,6 @@ check_info['huawei_capacity'] = {
     'snmp_scan_function'     : lambda oid: oid('.1.3.6.1.4.1.34774.4.1.1.4.0'),
     'group'                  : 'filesystem',
     'default_levels_variable': 'filesystem_default_levels',
-    'includes'               : [ 'size_trend.include', 'df.include' ],
+    'includes'               : [ 'df.include','size_trend.include' ],
 }
 

--- a/huawei/checks/huawei_nasfs
+++ b/huawei/checks/huawei_nasfs
@@ -68,6 +68,6 @@ check_info['huawei_nasfs'] = {
     'snmp_scan_function'     : lambda oid: oid('.1.3.6.1.2.1.1.2.0') == '.1.3.6.1.4.1.2011.2.91',
     'group'                  : 'filesystem',
     'default_levels_variable': 'filesystem_default_levels',
-    'includes'               : [ 'size_trend.include', 'df.include', 'huawei.include' ],
+    'includes'               : [ 'df.include', 'huawei.include','size_trend.include' ],
 }
 


### PR DESCRIPTION
The check crashes with error 'size_trend.include missing' if it's called before df.include