### PR TITLE
Update rbl_check

### DIFF
--- a/rbl/checks/rbl_check
+++ b/rbl/checks/rbl_check
@@ -15,7 +15,7 @@
 # to the Free Software Foundation, Inc., 51 Franklin St,  Fifth Floor,
 # Boston, MA 02110-1301 USA.
 
-def inventory_rbl_check(checkname, info):
+def inventory_rbl_check(info):
     inventory = set()
     for line in info:
 	inventory.add((line[0], None))


### PR DESCRIPTION
das mit dem checkname, info in der inventoryfunction laesst in der 1.6 den check_mk discovery service crashen