### PR TITLE
Fixed dell_sc_diskfolder check

### DIFF
--- a/dell_sc/checks/dell_sc_diskfolder
+++ b/dell_sc/checks/dell_sc_diskfolder
@@ -50,5 +50,5 @@ check_info["dell_sc_diskfolder"] = {
     'snmp_scan_function'    : lambda oid: 'compellent' in oid('.1.3.6.1.2.1.1.1.0').lower() and oid(".1.3.6.1.4.1.674.11000.2000.500.1.2.1.0") != None,
     'group'                 : 'filesystem',
     'default_levels_variable': 'filesystem_default_levels',
-    'includes'              : [ "df.include" ],
+    'includes'              : [ "df.include", "size_trend.include" ],
 }

--- a/dell_sc/checks/dell_sc_diskfolder
+++ b/dell_sc/checks/dell_sc_diskfolder
@@ -50,5 +50,5 @@ check_info["dell_sc_diskfolder"] = {
     'snmp_scan_function'    : lambda oid: 'compellent' in oid('.1.3.6.1.2.1.1.1.0').lower() and oid(".1.3.6.1.4.1.674.11000.2000.500.1.2.1.0") != None,
     'group'                 : 'filesystem',
     'default_levels_variable': 'filesystem_default_levels',
-    'includes'              : [ "df.include", "size_trend.include" ],
+    'includes'              : [ "size_trend.include", "df.include" ],
 }

--- a/dell_sc/web/plugins/metrics/dell_sc.py
+++ b/dell_sc/web/plugins/metrics/dell_sc.py
@@ -16,4 +16,7 @@
 # to the Free Software Foundation, Inc., 51 Franklin St,  Fifth Floor,
 # Boston, MA 02110-1301 USA.
 
+from cmk.gui.plugins.metrics import check_metrics
+from cmk.gui.plugins.metrics.check_mk import df_translation
+
 check_metrics["check_mk-dell_sc_diskfolder"] = df_translation


### PR DESCRIPTION
Hi,
i've updated our check_mk servers from 1.5.0p21 to 1.6.0p11 and also updated the dell_sc plugin from 1.5 to 2.0 to be compatible.

But receiving:

Exception | MKGeneralException (Function size_trend not found. Please include "size_trend.include" in your check)
-- | --
Traceback | File "/omd/sites/vaf/lib/python/cmk_base/checking.py", line 320, in execute_check     raw_result = check_function(item, determine_check_params(params), section_content)   File "/omd/sites/vaf/local/share/check_mk/checks/dell_sc_diskfolder", line 33, in check_dell_sc_diskfolder     return df_check_filesystem_list(item, params, fslist)   File "/omd/sites/vaf/share/check_mk/checks/df.include", line 291, in df_check_filesystem_list     inodes_data.get("inodes_avail", None), params)   File "/omd/sites/vaf/share/check_mk/checks/df.include", line 396, in df_check_filesystem_single     used_mb, size_mb, this_time)   File "/omd/sites/vaf/share/check_mk/checks/df.include", line 33, in size_trend     raise MKGeneralException('Function size_trend not found. Please include '
Local Variables | {'_args': ('df',            u'/10K',            'disk',            {'inodes_levels': (10.0, 5.0),             'levels': (85.0, 90.0),             'levels_low': (50.0, 60.0),             'levels_mb': (32106444.8, 33995059.2),             'levels_text': '(warn/crit at 85.0%/90.0%)',             'magic_normsize': 20,             'show_inodes': 'onlow',             'show_levels': 'onmagic',             'show_reserved': False,             'trend_perfdata': True,             'trend_range': 24,             'trend_timeleft': (48, 24)},            31093760,            37772288,            None),  '_kwargs': {}}
Crash Type | check
Time | 2020-05-15 16:26:02
Operating System | buster
Check_MK Version | 1.6.0p11
Edition | cre
Core | nagios
Python Version | 2.7.17 (default, Apr 2 2020, 12:08:56) [GCC 8.2.0]
Python Module Paths | /omd/sites/vaf/local/lib/python/omd/sites/vaf/lib/python/_pdbpp_path_hack/omd/sites/vaf/lib/python27.zip/omd/sites/vaf/lib/python2.7/omd/sites/vaf/lib/python2.7/plat-linux2/omd/sites/vaf/lib/python2.7/lib-tk/omd/sites/vaf/lib/python2.7/lib-old/omd/sites/vaf/lib/python2.7/lib-dynload/omd/sites/vaf/lib/python2.7/site-packages/omd/sites/vaf/lib/python

This is fixed in this pr.
Thanks for your work on dell_sc plugin !