### PR TITLE
rspamd: fix edge case with scanned = 0

### DIFF
--- a/rspamd/checks/rspamd
+++ b/rspamd/checks/rspamd
@@ -56,23 +56,32 @@ def check_rspamd(_no_item, params, info):
                     rate[key] = {}
                 for key2, value2 in data[key].iteritems():
                     if type(value2) == int:
-                        if key2 in info[key]:
-                            data[key][key2] = info[key][key2]
-                            rate[key][key2] = get_rate('rspamd.%s.%s' % (key, key2), now, data[key][key2])
-                        else:
-                            rate[key][key2] = 0.0
+                        if key2 in info:
+                            if key2 in info[key]:
+                                data[key][key2] = info[key][key2]
+                                rate[key][key2] = get_rate('rspamd.%s.%s' % (key, key2), now, data[key][key2])
+                            else:
+                                rate[key][key2] = 0.0
 
         total = data['scanned']
         total_rate = rate['scanned']
 
         for key, value in data.iteritems():
             if type(value) == int:
-                yield 0, '%d %s (%0.2f%%)' % (value, key, value*100.0/total), [ ('rspamd_%s_rate' % key, rate[key]) ]
+                if total != 0:
+                    yield 0, '%d %s (%0.2f%%)' % (value, key, value*100.0/total), [ ('rspamd_%s_rate' % key, rate[key]) ]
+                else:
+                    yield 0, '%d %s (%0.2f%%)' % (value, key, 0), [ ('rspamd_%s_rate' % key, rate[key]) ]
             elif type(value) == dict:
                 for key2, value2 in data[key].iteritems():
                     if type(value2) == int:
-                        yield ( 0, '%d %s (%0.2f%%)' % (value2, key2, value2*100.0/total),
-                                [ ('rspamd_%s_%s_rate' % (key, key2.replace(' ', '_')), rate[key][key2]) ] )
+                        if key2 in info:
+                            if total != 0:
+                                yield ( 0, '%d %s (%0.2f%%)' % (value2, key2, value2*100.0/total),
+                                        [ ('rspamd_%s_%s_rate' % (key, key2.replace(' ', '_')), rate[key][key2]) ] )
+                            else:
+                                yield ( 0, '%d %s (%0.2f%%)' % (value2, key2, 0),
+                                        [ ('rspamd_%s_%s_rate' % (key, key2.replace(' ', '_')), rate[key][key2]) ] )
     
 check_info['rspamd'] = {
     'parse_function'         : parse_rspamd,


### PR DESCRIPTION
If there are no mails scanned, rspamc does not output the dict "actions", hence the check fails.
Added test for existing "actions" section in info.
Additionally, if there are no mails scanned, "total" remains 0, which fails the rate calculation later (division by zero)