### PR TITLE
universal usable shebang for the wireguard plugin

### DIFF
--- a/wireguard/agents/plugins/wireguard
+++ b/wireguard/agents/plugins/wireguard
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 wg=$(which wg)
 


### PR DESCRIPTION
make it usable on other un*x variants like freebsd etc.