### PR TITLE
Update filehandles inventory function

### DIFF
--- a/filehandles/checks/filehandles
+++ b/filehandles/checks/filehandles
@@ -78,19 +78,11 @@ def inventory_filehandles(info):
 
     inventory = []
     rules = []
-    for rule in inventory_filehandles_rules:
-        taglist, hostlist = rule[1:3]
-        if len(rule) >= 4:
-            options = rule[3]
-            if options.get("disabled"):
-                continue
-        # Filter out entries with do not match our current host
-        if not hosttags_match_taglist(tags_of_host(host_name()), taglist) \
-           or not in_extraconf_hostlist(hostlist, host_name()):
-            continue
-        v = rule[0]
-        rules.append((v['descr'], v.get('match'), v.get('user')))
-
+    
+    for value in host_extra_conf(host_name(), inventory_filehandles_rules):
+    # Extract the list of processes
+    rules.append((value['descr'], value.get('match'), value.get('user')))
+  
     for line in info:
         if line[1] == 'global':
             inventory.append( ('global', {}) )


### PR DESCRIPTION
Changed inventory function to use the Checkmk host_extra_conf() function instead of manually parsing the ruleset.
Accessing a rule dictionary object with array indexes (e.g. rule[1:3]) leads to an "unhashable type" error in Python 2.7 and below, as the rules are non-ordered dictionaries. Dictionaries are only ordered by default starting with Python 3.6, which is not the Python version shipped with Checkmk 1.6.

fixes https://github.com/HeinleinSupport/check_mk_extensions/issues/57