### PR TITLE
Fixed rspamd metrics on Check MK 2.0.0p2

### DIFF
--- a/rspamd/web/plugins/metrics/rspamd.py
+++ b/rspamd/web/plugins/metrics/rspamd.py
@@ -84,7 +84,7 @@ graph_info["rspamd_ham_spam"] = {
                  ( 'rspamd_spam_count_rate', 'stack' ),
                  ( 'rspamd_scanned_rate', 'line' ),
                ],
-    })
+    }
 
 graph_info["rspamd_actions"] = {
     'title': _('Rspamd Actions'),
@@ -96,4 +96,4 @@ graph_info["rspamd_actions"] = {
                  ( 'rspamd_actions_add_header_rate', 'stack' ),
                  ( 'rspamd_scanned_rate', 'line' ),
                ],
-    })
+    }


### PR DESCRIPTION
Hi,

i've updated my rspamd plugin to 2.0 and my check mk from 2.0.0p1 to 2.0.0p2.
On the update process i received the message:
`
-| Failed to load plugin /omd/sites/NAME/local/share/check_mk/web/plugins/metrics/rspamd.py: unmatched ')' (<string>, line 87)
-| Traceback (most recent call last):
-|   File "/omd/sites/NAME/lib/python3/cmk/gui/utils/__init__.py", line 172, in load_web_plugins
-|     exec(f.read(), globalvars)
-|   File "<string>", line 87
-|     })
-|      ^
-| SyntaxError: unmatched ')'
-|
-| ERROR: Failed to load some GUI plugins. You will either have
-|        to remove or update them to be compatible with this
-|        Checkmk version.
-|
`

It seems to be there are 2 ) to much ;)
I've fixed it.