### PR TITLE
ceph: Use only first part of hostname

### DIFF
--- a/ceph/agents/plugins/ceph
+++ b/ceph/agents/plugins/ceph
@@ -37,7 +37,7 @@ class RadosCMD(rados.Rados):
 cluster = RadosCMD(conffile='/etc/ceph/ceph.conf')
 cluster.connect()
 
-hostname = socket.gethostname()
+hostname = socket.gethostname().split('.', 1)[0]
 fqdn = socket.getfqdn()
 
 res = cluster.command_mon("status")


### PR DESCRIPTION
socket.gethostname() can return an FQDN if that's what is set as hostname in the kernel. But since the FQDN is checked separately, it makes sense to only use the first part of the hostname (if there are multiple)