### PR TITLE
ceph: Honor muted health warnings

### DIFF
--- a/ceph/lib/check_mk/base/plugins/agent_based/cephstatus.py
+++ b/ceph/lib/check_mk/base/plugins/agent_based/cephstatus.py
@@ -128,12 +128,15 @@ def check_cephstatus(item, params, section) -> CheckResult:
                              summary='Overall Health OK')
             elif 'checks' in section['health']:
                 for check, data in section['health']['checks'].items():
-                    if data['severity'] == 'HEALTH_WARN':
-                        yield Result(state=State.WARN,
-                                     summary=check + ": " + data['summary']['message'])
+                    summary = check + ": " + data['summary']['message']
+                    if data.get('muted', False):
+                        state = State.OK
+                        summary += " (muted)"
+                    elif data['severity'] == 'HEALTH_WARN':
+                        state = State.WARN
                     else:
-                        yield Result(state=State.CRIT,
-                                     summary=check + ": " + data['summary']['message'])
+                        state = State.CRIT
+                    yield Result(state=state, summary=summary)
         elif 'overall_status' in section['health']:
             if section['health']['overall_status'] == 'HEALTH_OK':
                 yield Result(state=State.OK,


### PR DESCRIPTION
Previously, when you used "ceph health mute", the health warning would show up regardlessly if anything else caused the overall status to be non-OK.

This commit fixes that in that it adds a hint that the item is muted.