### PR TITLE
Remove deprecated import of quote_shell_string

### DIFF
--- a/check_calculate/checks/check_calculate
+++ b/check_calculate/checks/check_calculate
@@ -17,7 +17,7 @@
 # to the Free Software Foundation, Inc., 51 Franklin St,  Fifth Floor,
 # Boston, MA 02110-1301 USA.
 
-from cmk.utils import quote_shell_string, debug
+from cmk.utils import debug
 from pprint import pprint
 
 def check_calculate_arguments(params):


### PR DESCRIPTION
https://github.com/Checkmk/checkmk/commit/3c746adca4da525a13f2a9ce02ee2a64e238f92f

This also fixes compatibility for cmk2.2 in the future.