### PR TITLE
Close the sslcertificates section

### DIFF
--- a/sslcertificates/agents/windows/plugins/sslcertificates.ps1
+++ b/sslcertificates/agents/windows/plugins/sslcertificates.ps1
@@ -34,3 +34,4 @@ foreach ($_ in Get-ChildItem -Recurse Cert:\CurrentUser\My) {
 
   $data | ConvertTo-Json -Compress
 }
+Write-Host '<<<>>>'


### PR DESCRIPTION
Close this section to avoid getting input or errors from other plugins to the wrong check.

Write-Host '<<<>>>' at the end on line 37