### PR TITLE
distribution: heinlein destroys Catalog of check plugins.

### DIFF
--- a/updater_hostname/checkman/updater_hostname
+++ b/updater_hostname/checkman/updater_hostname
@@ -2,7 +2,6 @@ title: Check_MK Updater Hostname
 agents: linux
 catalog: os
 license: GPL
-distribution: heinlein
 description:
  Monitor the configured hostname of the agent updater plugin
 


### PR DESCRIPTION
From 2.2.0p9 on distribution: heinlein destroys Catalog of check plugins, for whatever reason. I did not troubleshoot further, but deleting it fixes the error. (Setup -> Services -> Catalog of check plugins)

Error:
Internal error: list indices must be integers or slices, not str

Traceback:
 File "/omd/sites/dev2/lib/python3/cmk/gui/wsgi/applications/checkmk.py", line 183, in _process_request
    resp = page_handler()
  File "/omd/sites/dev2/lib/python3/cmk/gui/wsgi/applications/utils.py", line 107, in _call_auth
    func()
  File "/omd/sites/dev2/lib/python3/cmk/gui/pages.py", line 187, in wrapper
    return hc().handle_page()
  File "/omd/sites/dev2/lib/python3/cmk/gui/pages.py", line 51, in handle_page
    self.page()
  File "/omd/sites/dev2/lib/python3/cmk/gui/pages.py", line 146, in <lambda>
    "page": lambda self: self._wrapped_callable[0](),
  File "/omd/sites/dev2/lib/python3/cmk/gui/wato/page_handler.py", line 87, in page_handler
    mode_instance = mode_registry.get(current_mode, ModeNotImplemented)()
  File "/omd/sites/dev2/lib/python3/cmk/gui/plugins/wato/utils/base_modes.py", line 31, in __init__
    self._from_vars()
  File "/omd/sites/dev2/lib/python3/cmk/gui/wato/pages/check_catalog.py", line 56, in _from_vars
    self._manpages = _get_check_catalog(only_path=())
  File "/omd/sites/dev2/lib/python3/cmk/gui/wato/pages/check_catalog.py", line 404, in _get_check_catalog
    subtree[path[-1]] = [