### PR TITLE
Fix Handling of Umlauts in SSL Certificate Subjects

### DIFF
--- a/sslcertificates/agents/plugins/sslcertificates
+++ b/sslcertificates/agents/plugins/sslcertificates
@@ -41,7 +41,7 @@ get_cert_info() {
 	    inform='PEM'
 	fi
 
-	cert_subject=$($OPENSSL x509 -inform $inform -noout -subject -in "$certfile" 2> /dev/null) || return
+	cert_subject=$($OPENSSL x509 -inform $inform -noout -subject -nameopt utf8 -in "$certfile" 2> /dev/null) || return
 	cert_subject=$(cut -d "=" -f 2- <<<"$cert_subject" | sed -e 's/"/\\"/g')
         if ! grep -q '@snakeoil.dom' <<<"$cert_subject"; then
 	    cert_startdate=$($OPENSSL x509 -inform $inform -noout -startdate -in "$certfile" | cut -d "=" -f 2 )


### PR DESCRIPTION
We recently changed our CA and the new one insists on using the proper organization name in their certificates which unfortunately contains an umlaut.
Forcing `openssl` to output that as proper UTF-8 seems to fix the crashing of the check.

Closes: #142 