### PR TITLE
Update entropy_avail.py

### DIFF
--- a/entropy_avail/web/plugins/wato/entropy_avail.py
+++ b/entropy_avail/web/plugins/wato/entropy_avail.py
@@ -6,6 +6,7 @@ from cmk.gui.valuespec import (
     Dictionary,
     Percentage,
     Tuple,
+    Integer,
 )
 
 from cmk.gui.plugins.wato import (


### PR DESCRIPTION
This change fixed a bug after upgrading to cmk 2.2: "Error: value 'Integer' not found"