### PR TITLE
added fix for check_temperature

### DIFF
--- a/apcaccess/lib/check_mk/base/plugins/agent_based/apcaccess.py
+++ b/apcaccess/lib/check_mk/base/plugins/agent_based/apcaccess.py
@@ -14,6 +14,9 @@
 # to the Free Software Foundation, Inc., 51 Franklin St,  Fifth Floor,
 # Boston, MA 02110-1301 USA.
 
+from .agent_based_api.v1 import (
+    get_value_store,
+)
 
 from .agent_based_api.v1.type_defs import (
     CheckResult,
@@ -167,6 +170,7 @@ def check_apcaccess_temp(item, params, section):
         itemp = section[item]['ITEMP'].split(' ')
         yield from temperature.check_temperature(float(itemp[0]),
                                                  params,
+                                                 unique_name='apcaccess_temp.%s' % item,
                                                  dev_unit=itemp[1].lower())
 
 register.check_plugin(


### PR DESCRIPTION
I found that when I used this in the latest version of CheckMK that I was getting an error on the check_temperature.

Followed the fix here and this worked: https://forum.checkmk.com/t/apc-apcupsd-conf-temperature-error-apc-smart-ups-1500-rm-trend-computation-error/32525

"It looks like that all “check_temperature” calls are broken if not explicitly set the “unique_name” and “value_store”."