### PR TITLE
[sslcertificates] add template name to plugin output

### DIFF
--- a/sslcertificates/agents/windows/plugins/sslcertificates.ps1
+++ b/sslcertificates/agents/windows/plugins/sslcertificates.ps1
@@ -1,3 +1,32 @@
+
+function Get-CertificateTemplateName($certificate)
+{
+  # The template name is stored in the Extension data.
+  # If available, the best is the extension named "Certificate Template Name", since it contains the exact name.
+  $templateExt = $certificate.Extensions | Where-Object{ ( $_.Oid.Value -eq '1.3.6.1.4.1.311.20.2' ) } | Select-Object -First 1
+  if ($templateExt) {
+    return $templateExt.Format(1)
+  }
+
+  # Our fallback option is the "Certificate Template Information" extension, it contains the name as part of a string like:
+  # "Template=Web Server v2(1.3.6.1.4.1.311.21.8.2499889.12054413.13650051.8431889.13164297.111.14326010.6783216)"
+  $templateExt = $certificate.Extensions | Where-Object{ ( $_.Oid.Value -eq '1.3.6.1.4.1.311.21.7' ) } | Select-Object -First 1
+  if ($templateExt) {
+    $information = $templateExt.Format(1)
+
+    # Extract just the template name in $Matches[1]
+    if($information -match "^\w+=(.+)\([0-9\.]+\)") {
+      return $Matches[1]
+    } else {
+      # No regex match, just return the complete information then
+      return $information
+    }
+  } else {
+    # No template name found
+    return $null
+  }
+}
+
 Write-Host '<<<sslcertificates:sep(0)>>>'
 
 $UnixEpoch = (Get-Date -Date "01/01/1970") ;
@@ -22,6 +51,7 @@ foreach ($CertLocation in $CertLocations) {
       thumb = $_.Thumbprint ;
       issuer = $issuer ;
       algosign = $_.SignatureAlgorithm.FriendlyName ;
+      template = Get-CertificateTemplateName($_) ;
     }
 
     $data | ConvertTo-Json -Compress

--- a/sslcertificates/lib/check_mk/base/plugins/agent_based/sslcertificates.py
+++ b/sslcertificates/lib/check_mk/base/plugins/agent_based/sslcertificates.py
@@ -76,6 +76,8 @@ def discover_sslcertificates(params, section):
             sl.append(ServiceLabel(u'sslcertificates/issuer', data['issuer']))
         if data.get('algosign'):
             sl.append(ServiceLabel(u'sslcertificates/algorithm', data['algosign']))
+        if data.get('template'):
+            sl.append(ServiceLabel(u'sslcertificates/template', data['template']))
         yield Service(item=name, labels=sl)
 
 def check_sslcertificates(item, params, section):
@@ -91,6 +93,9 @@ def check_sslcertificates(item, params, section):
         ignored = False
 
         yield Result(state=State.OK, summary="Subject: %s" % data['subj'])
+
+        if data.get('template'):
+            yield Result(state=State.OK, summary="Template: %s" % data['template'])
 
         if secondsremaining < 0:
             infotext = "expired %s ago on %s" % ( render.timespan(abs(secondsremaining)),


### PR DESCRIPTION
I have added the cert template (windows only) to the plugin output. With that a new service label will be created for each cert template.

With the labels you have a lot of new possibilities like searching for specific cert templates, configuring custom thresholds for specific cert templates and even disabling monitoring for certificates based on a specific template.

Right now, I need the possibility to disable certs based on a specific template, because windows takes care of the cert lifecycle itself, but sadly without deleting the old certificates which results in many meaningless errors.