### PR TITLE
Recommend VS Code extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "editorconfig.editorconfig",
+        "ms-vscode.powershell"
+    ]
+}


### PR DESCRIPTION
When using VS Code to edit the repo, the user is asked to install two extensions:
- Official editorconfig to make use of .editorconfig file
- Official Powershell module as the repo contains some Powershell scripts