### PR TITLE
Avoid crash in case params are not set

### DIFF
--- a/memcached/agent_based/memcached.py
+++ b/memcached/agent_based/memcached.py
@@ -168,6 +168,7 @@ def discover_memcached(section: Section) -> DiscoveryResult:
 
 def check_version(value: str, params: None | Mapping[str, str]) -> CheckResult:
     version = Version(value)
+    params = params or {}
     warn = Version(params.get("warn", "0"))
     crit = Version(params.get("crit", "0"))
     state = State.OK


### PR DESCRIPTION
Without that we see constant crashes for memcached check with the following error

```
AttributeError ('NoneType' object has no attribute 'get')

  File "/omd/sites/cmk/lib/python3/cmk/base/checkers.py", line 912, in get_aggregated_result
    check_result = check_function(**item_kw, **params_kw, **section_kws)
  File "/omd/sites/cmk/lib/python3/cmk/base/checkers.py", line 685, in __check_function
    return _aggregate_results(consume_check_results(check_function(*args, **kw)))
  File "/omd/sites/cmk/lib/python3/cmk/base/checkers.py", line 757, in consume_check_results
    for subr in subresults:
  File "/omd/sites/cmk/lib/python3/cmk/base/api/agent_based/register/check_plugins.py", line 96, in filtered_generator
    for element in generator(*args, **kwargs):
  File "/omd/sites/cmk/local/lib/python3/cmk_addons/plugins/memcached/agent_based/memcached.py", line 215, in check_memcached
    yield from check_version(
  File "/omd/sites/cmk/local/lib/python3/cmk_addons/plugins/memcached/agent_based/memcached.py", line 171, in check_version
    warn = Version(params.get("warn", "0"))
'NoneType' object has no attribute 'get'
```