### PR TITLE
Add letsencrypt use case

### DIFF
--- a/sslcertificates/agent_based/sslcertificates.py
+++ b/sslcertificates/agent_based/sslcertificates.py
@@ -15,8 +15,8 @@
 # to the Free Software Foundation, Inc., 51 Franklin St,  Fifth Floor,
 # Boston, MA 02110-1301 USA.
 
-import time
-import json
+from time import time, strftime, gmtime
+from json import loads
 from collections.abc import Mapping # type: ignore
 from typing import Any # type: ignore
 
@@ -39,43 +39,55 @@ SSLCertificatesSection = Mapping[str, Any]
 
 def parse_sslcertificates(string_table: StringTable) -> SSLCertificatesSection:
     section = {}
+
     for line in string_table:
         if line[0][0] == '{':
             # new json format for section
             name = False
-            data = json.loads(line[0])
+            data = loads(line[0])
             
             if 'file' in data:
                 name = data['file']
+
             if 'thumb' in data:
                 name = data['thumb']
+
             if name and 'subj' in data and 'expires' in data:
                 section[name] = data
+
         else:
             name = line[0]
             section[name] = {
                 'expires': int(line[1])
             }
+
             algosign = '/'
             if len(line) > 2:
                 algosign = line[2]
+
             if algosign[0] == '/':
                 # old agent plugin
                 algosign = ''
                 subjparts = line[2:]
+
             else:
                 subjparts = line[3:]
+
             if subjparts[0].startswith('issuer_hash='):
                 issuer_hash = subjparts[0][12:]
                 subjparts = subjparts[1:]
+
             else:
                 issuer_hash = None
+
             subject = " ".join(subjparts)
 
             section[name]['algosign'] = algosign
             section[name]['subj'] = subject
             section[name]['issuer_hash'] = issuer_hash
+
     return section
+
 
 agent_section_sslcertificates = AgentSection(
     name="sslcertificates",
@@ -88,42 +100,54 @@ def discover_sslcertificates(params, section: SSLCertificatesSection) -> Discove
         if 'min_lifetime' in params and 'starts' in data:
             if data['expires'] - data['starts'] < params['min_lifetime']:
                 continue
+
         sl = []
+
         if data.get('issuer_hash'):
             sl.append(ServiceLabel(u'sslcertificates/issuer_hash', data['issuer_hash']))
+
         if data.get('issuer'):
             sl.append(ServiceLabel(u'sslcertificates/issuer', data['issuer']))
+
         if data.get('algosign'):
             sl.append(ServiceLabel(u'sslcertificates/algorithm', data['algosign']))
+
         if data.get('template'):
             sl.append(ServiceLabel(u'sslcertificates/template', data['template']))
+
         yield Service(item=name, labels=sl)
+
 
 def check_sslcertificates(item: str, params, section: SSLCertificatesSection) -> CheckResult:
     warnalgos = params.get('warnalgo', [])
     ignore = params.get('ignore', None)
-    
-    if item in section:
+
+    if item not in section.keys():
+        yield Result(state=State.UNKNOWN, summary="Item not found")
+
+    else:
         data = section[item]
         
-        now = int(time.time())
+        now = int(time())
         secondsremaining = data['expires'] - now
         ignored = False
 
-        yield Result(state=State.OK, summary="Subject: %s" % data['subj'])
+        yield Result(state=State.OK, summary=f"Subject: {data['subj']}")
 
         if data.get('template'):
-            yield Result(state=State.OK, summary="Template: %s" % data['template'])
+            yield Result(state=State.OK, summary=f"Template: {data['template']}")
 
         if secondsremaining < 0:
             infotext = "expired %s ago on %s" % ( render.timespan(abs(secondsremaining)),
-                                                  time.strftime("%c", time.gmtime(data['expires'])))
+                                                  strftime("%c", gmtime(data['expires'])))
         else:
             infotext = "expires in %s on %s" % ( render.timespan(secondsremaining),
-                                                 time.strftime("%c", time.gmtime(data['expires'])))
+                                                 strftime("%c", gmtime(data['expires'])))
+
         if ignore and -secondsremaining > ignore["after"] * 86400.0:
-            yield Result(state=State.OK, summary=infotext + ', ignored because "%s"' % ignore["reason"])
+            yield Result(state=State.OK, summary=f"{infotext}, ignored because \"{ignore["reason"]}\"")
             ignored = True
+
         else:
             if secondsremaining > 0:
                 yield from check_levels(secondsremaining,
@@ -143,9 +167,12 @@ def check_sslcertificates(item: str, params, section: SSLCertificatesSection) ->
         if data.get('algosign'):
             infotext = "Signature Algorithm: %s" % data['algosign']
             state = State.OK
+
             if not ignored and data['algosign'] in warnalgos:
                 state = State.WARN
+
             yield Result(state=state, notice=infotext)
+
 
 check_plugin_sslcertificates = CheckPlugin(
     name="sslcertificates",

--- a/sslcertificates/agents/plugins/sslcertificates
+++ b/sslcertificates/agents/plugins/sslcertificates
@@ -18,52 +18,82 @@
 
 OPENSSL=$(which openssl)
 
-if [ ! -x "$OPENSSL" ]; then
-  exit
+if [ ! -x "$OPENSSL" ]
+then
+  exit 1
 fi
 
 CERT_DIRS="/etc/ssl/certs"
+CONFIG_FILE="$MK_CONFDIR/sslcertificates.cfg"
 
-CONFIG_FILE="$MK_CONFDIR/sslcertificates"
-
-if [ -r "$CONFIG_FILE" ]; then
-
+if [ -r "$CONFIG_FILE" ]
+then
   . "$CONFIG_FILE"
-
 fi
+
+cert_info() {
+  certfile="$1"
+  inform="$2"
+
+  cert_subject=$($OPENSSL x509 -inform $inform -noout -subject -nameopt utf8 -in "$certfile" 2> /dev/null) || return
+  cert_subject=$(cut -d "=" -f 2- <<<"$cert_subject" | sed -e 's/"/\\"/g')
+
+  if ! grep -q '@snakeoil.dom' <<<"$cert_subject"
+  then
+    cert_startdate=$($OPENSSL x509 -inform $inform -noout -startdate -in "$certfile" | cut -d "=" -f 2 )
+    cert_startdate_epoch=$(date --date "$cert_startdate" '+%s')
+    cert_enddate=$($OPENSSL x509 -inform $inform -noout -enddate -in "$certfile" | cut -d "=" -f 2 )
+    cert_enddate_epoch=$(date --date "$cert_enddate" '+%s')
+    cert_algosign=$($OPENSSL x509 -inform $inform -noout -text -in "$certfile" | awk '/Signature Algorithm: / { print $3; exit;}' )
+    cert_issuer_hash=$($OPENSSL x509 -inform $inform -noout -issuer_hash -in "$certfile" )
+    cert_issuer=$($OPENSSL x509 -inform $inform -noout -issuer -in "$certfile" | sed -e 's/ = /=/g' -e 's/, /,/g' -e 's/issuer=//' -e 's/"//g')
+
+    echo "{\"file\": \"$certfile\", \"starts\": $cert_startdate_epoch, \"expires\": $cert_enddate_epoch, \"algosign\": \"$cert_algosign\", \"issuer_hash\": \"$cert_issuer_hash\", \"issuer\": \"$cert_issuer\", \"subj\": \"$cert_subject\"}"
+  fi
+}
 
 get_cert_info() {
     certfile="$1"
     single="$2"
-    if [ -f "$certfile" -a -r "$certfile" -a \( ! -L "$certfile" -o "$single" \) ] && ! [[ $certfile =~ .*~$ ]] && ! [[ $certfile =~ .*_CA.crt$ ]] && ! [[ $certfile =~ .*/ca-certificates.crt$ ]]; then
+
+    if [ -f "$certfile" -a -r "$certfile" -a \( ! -L "$certfile" -o "$single" \) ] \
+      && ! [[ $certfile =~ .*~$ ]] && ! [[ $certfile =~ .*_CA.crt$ ]] && ! [[ $certfile =~ .*/ca-certificates.crt$ ]]
+    then
         inform='DER'
+
         if grep -q -- '-----BEGIN CERTIFICATE-----' "$certfile"; then
             inform='PEM'
         fi
 
-        cert_subject=$($OPENSSL x509 -inform $inform -noout -subject -nameopt utf8 -in "$certfile" 2> /dev/null) || return
-        cert_subject=$(cut -d "=" -f 2- <<<"$cert_subject" | sed -e 's/"/\\"/g')
-        if ! grep -q '@snakeoil.dom' <<<"$cert_subject"; then
-            cert_startdate=$($OPENSSL x509 -inform $inform -noout -startdate -in "$certfile" | cut -d "=" -f 2 )
-            cert_startdate_epoch=$(date --date "$cert_startdate" '+%s')
-            cert_enddate=$($OPENSSL x509 -inform $inform -noout -enddate -in "$certfile" | cut -d "=" -f 2 )
-            cert_enddate_epoch=$(date --date "$cert_enddate" '+%s')
-            cert_algosign=$($OPENSSL x509 -inform $inform -noout -text -in "$certfile" | awk '/Signature Algorithm: / { print $3; exit;}' )
-            cert_issuer_hash=$($OPENSSL x509 -inform $inform -noout -issuer_hash -in "$certfile" )
-            cert_issuer=$($OPENSSL x509 -inform $inform -noout -issuer -nameopt utf8 -in "$certfile" | sed -e 's/ = /=/g' -e 's/, /,/g' -e 's/issuer=//' -e 's/"//g')
+        cert_info "$certfile" "$inform"
 
-            echo "{\"file\": \"$certfile\", \"starts\": $cert_startdate_epoch, \"expires\": $cert_enddate_epoch, \"algosign\": \"$cert_algosign\", \"issuer_hash\": \"$cert_issuer_hash\", \"issuer\": \"$cert_issuer\", \"subj\": \"$cert_subject\"}"
-        fi
+    elif [ -L "$certfile" -a -r "$certfile" ] && [[ $certfile =~ cert\.pem$ ]]
+    then
+        cert_info "$certfile" "PEM"
     fi
+}
+
+get_certs() {
+    dir="$1"
+
+    for file in "$dir"/*
+    do
+        if [ -d "$file" ]
+        then
+            get_certs "$file"
+        else
+            get_cert_info "$file"
+        fi
+    done
 }
 
 echo '<<<sslcertificates:sep(0)>>>'
 
-for dir in $CERT_DIRS; do
-    if [ -d "$dir" ]; then
-        for certfile in "$dir"/*; do
-            get_cert_info "$certfile"
-        done
+for dir in $CERT_DIRS
+do
+    if [ -d "$dir" ]
+    then
+        get_certs $dir
     else
         get_cert_info "$dir" 1
     fi

--- a/sslcertificates/lib/python3/cmk/base/cee/plugins/bakery/sslcertificates.py
+++ b/sslcertificates/lib/python3/cmk/base/cee/plugins/bakery/sslcertificates.py
@@ -30,13 +30,15 @@ def get_sslcertificates_files(conf: Dict[str, Any]) -> FileGenerator:
     yield Plugin(base_os=OS.LINUX,
                  source=Path("sslcertificates"),
                  interval=int(conf.get("interval", 0)))
+
     yield Plugin(base_os=OS.WINDOWS,
                  source=Path("sslcertificates.ps1"),
                  interval=int(conf.get("interval", 0)))
+
     if 'directories' in conf:
         yield PluginConfig(base_os=OS.LINUX,
                            lines=['CERT_DIRS="%s"' % " ".join(conf['directories'])],
-                           target=Path("sslcertificates"),
+                           target=Path("sslcertificates.cfg"),
                            include_header=True)
 
 register.bakery_plugin(


### PR DESCRIPTION
Hi Robert,

thank you for the great work of this check. I have enhanced a little to get letsencrypt running easily.
If you add main path /etc/letsencrypt/live as directory, then all subdirectories will be checked and the certs are shown.

- Specify main directory for letsencrypt certificates and get all certs checked
- Reformatted for better reading
- Added some python3 functionality

Best regards
Sven