### PR TITLE
small fix for powershell script

### DIFF
--- a/sslcertificates/agents/windows/plugins/sslcertificates.ps1
+++ b/sslcertificates/agents/windows/plugins/sslcertificates.ps1
@@ -56,7 +56,7 @@ foreach ($CertLocation in $CertLocations) {
     Else {$subject = $cert.Thumbprint}
 
     # Reverse issuer, so it starts with e.g. C=US to match the output of the Linux agent.
-    $issuer = $cert.Issuer -split ',' | ForEach-Object { $cert.Trim() }
+    $issuer = $cert.Issuer -split ',' | ForEach-Object { $_.Trim() }
     [array]::Reverse($issuer)
     $issuer = $issuer -join ','
 


### PR DESCRIPTION
Only small fix for $_ instead of $cert.
ForEach-Object produces $_ as reverence for every object.

description is inside #217 