### PR TITLE
Velocloud_Link: Fix crash with empty data and add threshold-support or latencies2

### DIFF
--- a/velocloud/lib/check_mk/base/plugins/agent_based/velocloud.py
+++ b/velocloud/lib/check_mk/base/plugins/agent_based/velocloud.py
@@ -232,7 +232,7 @@ def parse_velocloud_link(string_table: StringTable):
             'rx_latency': float(rxlatency) / 1000.0,
             'if_out_errors': int(txlost),
             'if_in_errors': int(rxlost),
-            'raw_state': int(vpnstate),
+            'raw_state': int(vpnstate) if vpnstate.isdigit() else "",
             'state': _velocloud_map_vpn_state.get(vpnstate, (State.UNKNOWN, 'Unknown')),
             'if_out_unicast': int(txpackets),
             'if_in_unicast': int(rxpackets),
@@ -292,7 +292,7 @@ def check_velocloud_link(item, params, section) -> CheckResult:
             yield Result(state=State.OK,
                          summary='State is %s' % data['state'][1])
         for key, value in data.items():
-            if key in [ 'name', 'raw_state', 'state' ]:
+            if key in [ 'name', 'raw_state', 'state', "rx_latency", "tx_latency" ]:
                 continue
             if key.endswith('jitter') or key.endswith('latency'):
                 yield Metric(key, value)
@@ -300,11 +300,28 @@ def check_velocloud_link(item, params, section) -> CheckResult:
                 rate = get_rate(vs, 'velocloud_link.%s.%s' % (item, key), now, value)
                 yield Metric(key, rate)
 
+        yield from check_levels(
+            data['rx_latency'],
+            metric_name='rx_latency',
+            levels_upper=params.get('rx_latency'),
+            label='RX Latency',
+            render_func=lambda v: "%.3f ms" % v,
+        )
+
+        yield from check_levels(
+            data['tx_latency'],
+            metric_name='tx_latency',
+            levels_upper=params.get('tx_latency'),
+            label='TX Latency',
+            render_func=lambda v: "%.3f ms" % v,
+        )
+
 register.check_plugin(
     name='velocloud_link',
     service_name="VeloCloud Link %s",
     discovery_function=discover_velocloud_link,
     check_function=check_velocloud_link,
+    check_ruleset_name="velocloud_link",
     check_default_parameters={
         'raw_state': 0,
     },

--- a/velocloud/web/plugins/wato/velocloud_link_rule.py
+++ b/velocloud/web/plugins/wato/velocloud_link_rule.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+
+from cmk.gui.i18n import _
+
+from cmk.gui.plugins.wato.utils import (
+    rulespec_registry,
+    CheckParameterRulespecWithItem,
+    RulespecGroupCheckParametersApplications,
+)
+
+from cmk.gui.valuespec import (
+    Dictionary,
+    Float,
+    TextAscii,
+    Tuple,
+)
+
+
+def _item_spec_velocloud_link():
+    return TextAscii(
+        title=_("Item"),
+    )
+
+
+def _parameter_valuespec_velocloud_link():
+    return Dictionary(
+        required_keys=[],
+        elements=[
+            (
+                "rx_latency",
+                Tuple(
+                    title=_("Upper RX Latency Levels"),
+                    elements=[
+                        Float(
+                            title=_("Warning at"),
+                            default_value=20,
+                            unit="ms",
+                            display_format="%.3f",
+                        ),
+                        Float(
+                            title=_("Critical at"),
+                            default_value=50,
+                            unit="ms",
+                            display_format="%.3f",
+                        ),
+                    ],
+                ),
+            ),
+            (
+                "tx_latency",
+                Tuple(
+                    title=_("Upper TX Latency Levels"),
+                    elements=[
+                        Float(
+                            title=_("Warning at"),
+                            default_value=20,
+                            unit="ms",
+                            display_format="%.3f",
+                        ),
+                        Float(
+                            title=_("Critical at"),
+                            default_value=50,
+                            unit="ms",
+                            display_format="%.3f",
+                        ),
+                    ],
+                ),
+            ),
+        ],
+    )
+
+
+rulespec_registry.register(
+    CheckParameterRulespecWithItem(
+        check_group_name="velocloud_link",
+        group=RulespecGroupCheckParametersApplications,
+        parameter_valuespec=_parameter_valuespec_velocloud_link,
+        item_spec=_item_spec_velocloud_link,
+        title=lambda: _("VeloCloud Link thresholds"),
+    )
+)


### PR DESCRIPTION

PR contains fix for velocloud_link,: A customer-system returned "" instead of a digit for the state.
PR also contains adding thresholds for link latencies.

Unfortunately we could not migrate to CMK 2.4 API yet.


