### PR TITLE
Fix formatting and improve subject handling

### DIFF
--- a/sslcertificates/agents/windows/plugins/sslcertificates.ps1
+++ b/sslcertificates/agents/windows/plugins/sslcertificates.ps1
@@ -51,8 +51,8 @@ $CertLocations = "Cert:\LocalMachine\My", "Cert:\CurrentUser\My"
 
 foreach ($CertLocation in $CertLocations) {
   foreach ($cert in Get-ChildItem -Recurse $CertLocation) {
-    If ($cert.DnsNameList) {$subject = $cert.DnsNameList}
-    ElseIf ($cert.Subject) {$subject = $cert.Subject}
+    If ($cert.DnsNameList -and @($cert.DnsNameList).Count -gt 0) {$subject = $cert.DnsNameList -join ','}
+    ElseIf ($cert.Subject -and $cert.Subject.Trim() -ne "") {$subject = $cert.Subject}
     Else {$subject = $cert.Thumbprint}
 
     # Reverse issuer, so it starts with e.g. C=US to match the output of the Linux agent.
@@ -63,7 +63,7 @@ foreach ($CertLocation in $CertLocations) {
     $data = [ordered]@{
       starts = (New-TimeSpan -Start $UnixEpoch -End $cert.NotBefore).TotalSeconds ;
       expires = (New-TimeSpan -Start $UnixEpoch -End $cert.NotAfter).TotalSeconds ;
-      subj = $subject.Unicode ;
+      subj = $subject ;
       thumb = $cert.Thumbprint ;
       issuer = $issuer ;
       algosign = $cert.SignatureAlgorithm.FriendlyName ;
@@ -73,3 +73,4 @@ foreach ($CertLocation in $CertLocations) {
     $data | ConvertTo-Json -Compress
   }
 }
+


### PR DESCRIPTION
Hello,

A certificate with no value for DnsNameList with make the Subject : None in the Checkmk SSL Certificate service, even if the certificate has a subject.

Given certificate data:
```
PSParentPath             : Microsoft.PowerShell.Security\Certificate::LocalMachine\My
DnsNameList              :
NotAfter                 : 8/4/2026 11:13:46 PM
NotBefore                : 8/4/2025 11:13:46 PM
Thumbprint               : ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
Issuer                   : DC=Windows Azure CRP Certificate Generator
Subject                  : DC=Windows Azure CRP Certificate Generator
```
Agent output is:
```
{"starts":1757892018,"expires":1789428018,"subj":null,"thumb":"ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ","issuer":"DC=Windows Azure CRP Certificate Generator","algosign":"sha256RSA","template":null}
```
**"subj":null** as it tries to decode DnsNameList
<img width="596" height="79" alt="image" src="https://github.com/user-attachments/assets/a3899b36-9d17-476d-8e7e-8d67923647e3" />

The proposed change fix that by handling properly the DnsNameList; if it is empty ignore it, if it is not empty then convert the list to string.

_By the way, I don't understand why DnsNameList is used for subject when a Subject exists._