### PR TITLE
IMP // fixes JSON parsing for nan and inf values in rspamd output

### DIFF
--- a/rspamd/agent_based/rspamd.py
+++ b/rspamd/agent_based/rspamd.py
@@ -38,8 +38,12 @@ Section = Mapping[str, Any]
 
 def parse_rspamd(string_table: StringTable) -> Section:
     import json
+    import re
     try:
-        return json.loads(" ".join([item for sublist in string_table for item in sublist]))
+        raw = " ".join([item for sublist in string_table for item in sublist])
+        # rspamd kann nan/inf Werte ausgeben, die kein gültiges JSON sind
+        raw = re.sub(r'\b(nan|inf)\b', 'null', raw)
+        return json.loads(raw)
     except ValueError:
         return {}
 


### PR DESCRIPTION
The rspamd check was returning empty results on my system. 
rspamd can output nan (and inf) values which are not valid JSON.

For example:
```
rspamc --compact stat
{"version":"3.15.0","config_id":"4omjrpe7f1rnhdkcatyg3zghxfghnj893px61crn6js8igqu5xa54k1futhurkn7begpd5smo4m93jxeimeshh57uo4e9dcegdad5bb","uptime":2713,"read_only":false,"scanned":8866,"learned":0,"actions":{"reject":4,"soft reject":0,"rewrite subject":0,"add header":63,"greylist":243,"no action":8556},"scan_times":[nan,nan,nan,nan,nan,nan,nan,nan,nan,nan,nan,nan,nan,nan,nan,nan,nan,nan,nan,nan,nan,nan,nan,nan,nan,nan,nan,nan,nan,nan,nan],"spam_count":67,"ham_count":8799,"connections":0,"control_connections":51,"pools_allocated":260,"pools_freed":233,"bytes_allocated":17604744,"chunks_allocated":47,"shared_chunks_allocated":2,"chunks_freed":0,"chunks_oversized":0,"fragmented":0,"total_learns":0,"statfiles":[{"revision":0,"users":0,"used":0,"total":0,"size":0,"symbol":"BAYES_SPAM","type":"redis","languages":0},{"revision":0,"users":0,"used":0,"total":0,"size":0,"symbol":"BAYES_HAM","type":"redis","languages":0}],"fuzzy_hashes":{"rspamd.com":276381068},"scan_time":0.020000}
```

Solution: These are now replaced with null before parsing.

I've used regex with word boundaries (\b) to ensure only nan and inf are replaced and no other words containing these strings (e.g. "banana").

Please create a new release and thanks for your work on all of these Check MK plugins.