### PR TITLE
dir_size: Only use one grep call

### DIFF
--- a/dir_size/agents/plugins/dir_size
+++ b/dir_size/agents/plugins/dir_size
@@ -27,6 +27,5 @@ globfiles() (
 
 if [ -e "$MK_CONFDIR/dir_size.cfg" ]; then
     echo '<<<dir_size>>>'
-    grep -v ^# $MK_CONFDIR/dir_size.cfg | grep -v ^$ | tr '\n' '\0' | globfiles | xargs -0 du -s
+    grep -v -e ^# -e ^$ $MK_CONFDIR/dir_size.cfg | tr '\n' '\0' | globfiles | xargs -0 du -s
 fi
-


### PR DESCRIPTION
Eliminate one of two `grep` calls by combining both into one.