### PR TITLE
Fix item translation in check_apcaccess_elphase

### DIFF
--- a/apcaccess/agent_based/apcaccess.py
+++ b/apcaccess/agent_based/apcaccess.py
@@ -165,6 +165,10 @@ def discovery_apcaccess_elphase(params, section: Section) -> DiscoveryResult:
                 yield Service(item=instance)
 
 def check_apcaccess_elphase(item, params, section) -> CheckResult:
+    if 'upsname' in params:
+        item = params['upsname']
+    elif 'model' in params:
+        item = params['model']
     if item in section and "elphase" in section[item]:
         yield from elphase.check_elphase(item, params, {item: section[item]["elphase"]})
 


### PR DESCRIPTION
Small fix for the elphase check. When the `apcaccess_inventory` rule is set
to `servicedesc: upsname`, the `APC <name> Output` service ends up stuck on
"Item not found in monitoring data" — even though Status and Temperature
both work fine with the same setup.

Turns out the other two checks (`check_apcaccess` and `check_apcaccess_temp`)
both translate `item` back to the real section key using `params['upsname']`
before doing the lookup. `check_apcaccess_elphase` was missing that step,
so it kept looking for the friendly name in a dict keyed by the config name
and never found anything.