### PR TITLE
Feature: support configuration of different Windows cert stores

### DIFF
--- a/sslcertificates/agents/windows/plugins/sslcertificates.ps1
+++ b/sslcertificates/agents/windows/plugins/sslcertificates.ps1
@@ -49,7 +49,20 @@ $UnixEpoch = (Get-Date -Date "01/01/1970") ;
 
 $CertLocations = "Cert:\LocalMachine\My", "Cert:\CurrentUser\My"
 
+$MkConfDir = $env:MK_CONFDIR
+if (!$MkConfDir) {
+  $MkConfDir = "%PROGRAMDATA%\checkmk\agent\config"
+}
+
+$ConfigFile = "${MkConfDir}\sslcertificates_cfg.ps1"
+if (Test-Path -Path $ConfigFile) {
+  . $ConfigFile
+}
+
 foreach ($CertLocation in $CertLocations) {
+  if (-Not (Test-Path -Path $CertLocation)) {
+    continue
+  }
   foreach ($cert in Get-ChildItem -Recurse $CertLocation) {
     If ($cert.DnsNameList -and @($cert.DnsNameList).Count -gt 0) {$subject = $cert.DnsNameList -join ','}
     ElseIf ($cert.Subject -and $cert.Subject.Trim() -ne "") {$subject = $cert.Subject}

--- a/sslcertificates/lib/python3/cmk/base/cee/plugins/bakery/sslcertificates.py
+++ b/sslcertificates/lib/python3/cmk/base/cee/plugins/bakery/sslcertificates.py
@@ -39,6 +39,10 @@ def get_sslcertificates_files(conf: Dict[str, Any]) -> FileGenerator:
                             lines=['CERT_DIRS="%s"' % " ".join(conf['directories'])],
                             target=Path("sslcertificates"),
                             include_header=True)
+            yield PluginConfig(base_os=OS.WINDOWS,
+                            lines=['$CertLocations = %s' % ", ".join(map( lambda directory: f'"{ directory }"', conf['directories']))]
+                            target=Path("sslcertificates_cfg.ps1"),
+                            include_header=True)
 
 register.bakery_plugin(
     name="sslcertificates",

--- a/sslcertificates/rulesets/sslcertificates.py
+++ b/sslcertificates/rulesets/sslcertificates.py
@@ -183,13 +183,13 @@ def _valuespec_agent_config_sslcertificates():
             "directories": DictElement(
                 parameter_form = List(
                     title = Title("Directories or filename patterns to look into for SSL certificate files"),
-                    help_text = Help("Enter path patterns that will be searched for certificate files. Only works on Linux. On Windows the agent plugin looks into the cert store."),
+                    help_text = Help("Enter path patterns that will be searched for certificate files. Only works on Linux. On Windows the agent plugin looks into the cert store. Different cert store locations can be specified"),
                     element_template = String(
                         field_size=80,
                         custom_validate=[
                             validators.MatchRegex(
-                                regex = r"^/\S+$",
-                                error_msg = "Directory paths must begin with <tt>/</tt> and must not contain spaces.",
+                                regex = r"^(/\S+$|Cert:.+)",
+                                error_msg = "On Linux directory paths must begin with <tt>/</tt> and must not contain spaces. On Windows cert store locations must begin with <tt>Cert:</tt>",
                             ),
                         ],
                     ),


### PR DESCRIPTION
Implementation for #256:
- generates a configuration file for Windows agents
- Windows agent can read a configuration file (sources sslcertificats_cfg.ps1 like the nvidia smi agent)
- Safety check for the windows agent to test cert location to avoid exceptions when Linux directory paths are configured for Windows