### PR TITLE
Sort certificates by expiration date

### DIFF
--- a/sslcertificates/agents/windows/plugins/sslcertificates.ps1
+++ b/sslcertificates/agents/windows/plugins/sslcertificates.ps1
@@ -50,7 +50,7 @@ $UnixEpoch = (Get-Date -Date "01/01/1970") ;
 $CertLocations = "Cert:\LocalMachine\My", "Cert:\CurrentUser\My"
 
 foreach ($CertLocation in $CertLocations) {
-  foreach ($cert in Get-ChildItem -Recurse $CertLocation) {
+  foreach ($cert in Get-ChildItem -Recurse $CertLocation | sort -Property NotAfter -Descending) {
     If ($cert.DnsNameList -and @($cert.DnsNameList).Count -gt 0) {$subject = $cert.DnsNameList -join ','}
     ElseIf ($cert.Subject -and $cert.Subject.Trim() -ne "") {$subject = $cert.Subject}
     Else {$subject = $cert.Thumbprint}


### PR DESCRIPTION
The certificate order is not defined. So if multiple certificates exist for the same subject this can result in different processing orders on different machines.
To behave them the same we order them by expiration date. This will also give us the same reproducable results in Checkmk.

This solves #259 for Windows and certificates in the same certificate store.