### PR TITLE
Sort certificates by expiration date to be more deterministic

### DIFF
--- a/sslcertificates/agent_based/sslcertificates.py
+++ b/sslcertificates/agent_based/sslcertificates.py
@@ -77,7 +77,7 @@ def parse_sslcertificates(string_table: StringTable) -> SSLCertificatesSection:
             section[name]['algosign'] = algosign
             section[name]['subj'] = subject
             section[name]['issuer_hash'] = issuer_hash
-    return section
+    return dict(sorted(section.items(), key=lambda item: item[1]['expires'], reverse=True))
 
 agent_section_sslcertificates = AgentSection(
     name="sslcertificates",


### PR DESCRIPTION
The certificate order may be different between machines which can result in different certificates being shown in Checkmk for the same subject. Checkmk shows the first certificate presented by the agent. To make it more deterministic we sort the list of certificates by expiration date to monitor the longest running certificate.

Should fix #259 and be more sustainable than #260. This works over all Windows certificate stores and Linux.