### PR TITLE
Fix None handling in SimpleLevels migration

### DIFF
--- a/msexch_database_size/agent_based/msexch_database_size.py
+++ b/msexch_database_size/agent_based/msexch_database_size.py
@@ -110,7 +110,7 @@ check_plugin_msexch_database_size = CheckPlugin(
     discovery_function=discover_msexch_database_size,
     check_function=check_msexch_database_size,
     check_default_parameters={
-        "size": None,
+        "size": ("no_levels", None),
         "availSpace": ("fixed", (20.0, 40.0)),
     },
     check_ruleset_name="msexch_database_size",

--- a/msexch_database_size/rulesets/msexch_database_size.py
+++ b/msexch_database_size/rulesets/msexch_database_size.py
@@ -19,11 +19,12 @@ def _migrate(params: object) -> dict:
     """Migrate legacy parameter formats."""
     if not isinstance(params, dict):
         # Very old format: just a size tuple
-        return {"size": ("fixed", params) if params else None}
+        return {"size": ("fixed", params) if params else ("no_levels", None)}
     migrated = dict(params)
     for key in ("size", "availSpace"):
         value = migrated.get(key)
         if value is None:
+            migrated[key] = ("no_levels", None)
             continue
         if isinstance(value, tuple) and len(value) == 2 and not isinstance(value[0], str):
             # Legacy format: (warn, crit) -> ("fixed", (warn, crit))


### PR DESCRIPTION
The issue was discovered while validating the plugin with `cmk-validate-plugins`.

`cmk-validate-plugins` reported an error for the `msexch_database_size` check because the default size value was `None`, while SimpleLevels expects `("no_levels", None)`.

```text
Default parameters 'check_default_parameters' specified by CheckPlugin 'msexch_database_size' cannot be read by referenced rule spec 'msexch_database_size': None
```

### Changes
* Use `("no_levels", None)` as the default value for `size`.
* Migrate legacy `None` values to `("no_levels", None)`.
* Migrate the very old non-dictionary format without levels to `("no_levels", None)`.

This keeps the `check_default_parameters` and `_migrate()` function consistent with the current `SimpleLevels` data model of the Checkmk Ruleset API.



